### PR TITLE
Fixes #79

### DIFF
--- a/src/app/modules/core/components/footer/footer.component.html
+++ b/src/app/modules/core/components/footer/footer.component.html
@@ -18,10 +18,10 @@
 								<th></th>
 								<th></th>
 								<th></th>
-								<th style="border-bottom: 1px solid rgba(0,0,0,0.5);"></th>
-								<th style="text-align: center; border-bottom: 1px solid rgba(0,0,0,0.5);">Time of</th>
-								<th style="border-bottom: 1px solid rgba(0,0,0,0.5);"></th>
 								<th></th>
+								<th style="border-bottom: 1px solid rgba(0,0,0,0.5);"></th>
+								<th style="text-align: center; border-bottom: 1px solid rgba(0,0,0,0.5);">Travel time after spill</th>
+								<th style="border-bottom: 1px solid rgba(0,0,0,0.5);"></th>
 								<th></th>
 							</tr>
 							<tr>
@@ -36,6 +36,7 @@
 								<th title="mg/L">Peak concentration</th>
 							</tr>
 							<tr>
+								<th></th>
 								<th>Q</th>
 								<th>D<sub>a</sub></th>
 								<th>L</th>
@@ -88,7 +89,9 @@
 								<th></th>
 								<th></th>
 								<th></th>
-								<th colspan="3" style="text-align:center;border-bottom: solid black 1px; padding: 4px 4px 4px 4px;">Time of</th>
+								<th style="border-bottom: 1px solid rgba(0,0,0,0.5);"></th>
+								<th style="text-align: center; border-bottom: 1px solid rgba(0,0,0,0.5);">Travel time after spill</th>
+								<th style="border-bottom: 1px solid rgba(0,0,0,0.5);"></th>
 								<th></th>
 							</tr>
 							<tr style="border-bottom: solid black 1px; padding: 4px 4px 4px 4px;">
@@ -103,6 +106,7 @@
 								<th title="mg/L">Peak concentration</th>
 							</tr>
 							<tr style="border-bottom: solid black 1px; padding: 4px 4px 4px 4px; vertical-align: center; text-align: center;">
+								<th></th>
 								<th>Q</th>
 								<th>D<sub>a</sub></th>
 								<th>L</th>

--- a/src/app/modules/core/components/report/report.component.html
+++ b/src/app/modules/core/components/report/report.component.html
@@ -103,7 +103,7 @@
 							<th></th>
 							<th></th>
 							<th style="border-bottom: 1px solid rgba(0,0,0,0.5);"></th>
-							<th style="text-align: center; border-bottom: 1px solid rgba(0,0,0,0.5);">Time of</th>
+							<th style="text-align: center; border-bottom: 1px solid rgba(0,0,0,0.5);">Travel time after spill</th>
 							<th style="border-bottom: 1px solid rgba(0,0,0,0.5);"></th>
 							<th></th>
 						</tr>
@@ -119,6 +119,7 @@
 							<th title="mg/L">Peak concentration</th>
 						</tr>
 						<tr style="border-bottom: solid black 1px; padding: 4px 4px 4px 4px; vertical-align: center; text-align: center;">
+							<th></th>
 							<th>Q</th>
 							<th>D<sub>a</sub></th>
 							<th>L</th>
@@ -220,7 +221,7 @@
 							<th></th>
 							<th></th>
 							<th style="border-bottom: 1px solid rgba(0,0,0,0.5);"></th>
-							<th style="text-align: center; border-bottom: 1px solid rgba(0,0,0,0.5);">Time of</th>
+							<th style="text-align: center; border-bottom: 1px solid rgba(0,0,0,0.5);">Travel time after spill</th>
 							<th style="border-bottom: 1px solid rgba(0,0,0,0.5);"></th>
 							<th></th>
 						</tr>
@@ -236,6 +237,7 @@
 							<th title="mg/L">Peak concentration</th>
 						</tr>
 						<tr style="border-bottom: solid black 1px; padding: 4px 4px 4px 4px; vertical-align: center; text-align: center;">
+							<th></th>
 							<th>Q</th>
 							<th>D<sub>a</sub></th>
 							<th>L</th>


### PR DESCRIPTION
In the footer and report tables 

- moved variables to the right (ex. Q - discharge)

- changed the "Time of" header to "Travel time after spill"

- moved the  "Travel time after spill" header to be above  - Leading edge, Peak Concentration, and Trailing edge