### PR TITLE
Fixes #112

### DIFF
--- a/src/assets/data/config.json
+++ b/src/assets/data/config.json
@@ -33,8 +33,8 @@
     ],
     "overlayLayers": [
       {
-        "name": "Texas",
-        "url": "https://txgeo.usgs.gov/arcgis/rest/services/Mapping/HydroBaseMapForTerrain/MapServer",
+        "name": "USGSHydroCached",
+        "url": "https://basemap.nationalmap.gov/arcgis/rest/services/USGSHydroCached/MapServer",
         "type": "agsTile",
         "layerOptions": {
           "opacity": 0.6,


### PR DESCRIPTION
Changed out the Texas map layer (https://txgeo.usgs.gov/arcgis/rest/services/Mapping/HydroBaseMapForTerrain/MapServer) for USGSHydroCached layer (https://basemap.nationalmap.gov/arcgis/rest/services/USGSHydroCached/MapServer) per a conversion with Marty and @HansVraga. There are still a couple duplicate place names like "United States" and some of the major rivers but it is definitely better. Let me know if this new layer is still detailed enough, and if so if there is a better name for the layer.