### PR TITLE
github action - update commit sha reference to full commit number

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
         aws-region: us-east-2
     - run: aws s3 cp /home/runner/work/TravelTime/TravelTime/dist/ s3://test.streamstats.usgs.gov/tot/ --recursive
     - name: GitHub Action for Slack
-      uses: Ilshidur/action-slack@9273a03
+      uses: Ilshidur/action-slack@9273a038d94644256c1ba855c9ed6f4391b9cd89
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
         aws-region: us-east-2
     - run: aws s3 cp /home/runner/work/TravelTime/TravelTime/dist/ s3://test.streamstats.usgs.gov/tot/ --recursive
     - name: GitHub Action for Slack
-      uses: Ilshidur/action-slack@9273a038d94644256c1ba855c9ed6f4391b9cd89
+      uses: Ilshidur/action-slack@v1.6.2
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       with:


### PR DESCRIPTION
Small update due to an incoming change in the Github Actions commit references.